### PR TITLE
docs: update binder URL

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -55,10 +55,7 @@ https://www.biorxiv.org/content/early/2018/01/05/243881
     :target: https://bofdat.readthedocs.io/en/latest/index.html
 .. |Buildstatus| image:: https://travis-ci.org/jclachance/BOFdat.svg?branch=master
     :target: https://travis-ci.org/jclachance/BOFdat
-
-.. |Binder| image::https://mybinder.org/badge.svg
-    :target: https://github.com/jclachance/BOFdat/blob/master/Example_usage/Example.ipynb
-
+.. |Binder| image:: https://mybinder.org/badge.svg :target: https://mybinder.org/v2/gh/jclachance/BOFdat/master?filepath=Example_usage%2FExample.ipynb
 
 Author: Jean-Christophe Lachance
 Date: 06-13-2018


### PR DESCRIPTION
The badge was not displaying correctly. This is copy&pasted from mybinder.org when filling in the information.